### PR TITLE
Fix rolling without aim data

### DIFF
--- a/script/common/dialog.js
+++ b/script/common/dialog.js
@@ -74,11 +74,13 @@ export async function prepareCombatRoll(rollData, actorRef) {
                       modifier : 0
                     };
                     const aim = html.find("#aim")[0]
-                    rollData.aim = {
-                      val : aim.value,
-                      isAiming : aim.value !== "0",
-                      text : aim?.options[aim.selectedIndex].text
-                    };
+                    if (aim) {
+                      rollData.aim = {
+                        val : aim.value,
+                        isAiming : aim.value !== "0",
+                        text : aim?.options[aim.selectedIndex].text
+                      };
+                    }
                     rollData.damageFormula = html.find("#damageFormula")[0].value.replace(' ', '');
                     rollData.damageType = html.find("#damageType")[0].value;
                     rollData.damageBonus = parseInt(html.find("#damageBonus")[0].value, 10);


### PR DESCRIPTION
Was prepping some items for my game master, noticed that weapons with the `Spray` keyword have broken attack rolls.
After a little investigating turns out, as those weapons skip the attack roll. thus the dialog.js will not have any kind of aiming data. So far the code has not checked if that data is available or not and tried to access it regardless, breaking the damage roll for these kind of weapons.

The pr just adds a small if check if there is aim data present, and if not, does not add said data to the `rollData` object