### PR TITLE
Bugfixes

### DIFF
--- a/script/common/chat.js
+++ b/script/common/chat.js
@@ -11,7 +11,7 @@ export function chatListeners(html) {
     html.on("click", ".invoke-test", onTestClick.bind(this));
     html.on("click", ".invoke-damage", onDamageClick.bind(this));
     html.on("click", ".reload-Weapon", onReloadClick.bind(this));
-    html.on("click", ".dark-heresy.chat.roll>.background.border", onChatRollClick.bind(this));
+    html.on("dblclick", ".dark-heresy.chat.roll>.background.border", onChatRollClick.bind(this));
 }
 
 /**

--- a/script/common/config.js
+++ b/script/common/config.js
@@ -134,7 +134,7 @@ Dh.advanceStagesSkills = {
     10: "ADVANCE.TRAINED",
     20: "ADVANCE.EXPERIENCED",
     30: "ADVANCE.VETERAN"
-}
+};
 
 Dh.characteristicCosts = [
     [0, 0, 0],

--- a/script/common/dialog.js
+++ b/script/common/dialog.js
@@ -59,7 +59,7 @@ export async function prepareCommonRoll(rollData) {
  * @param {DarkHeresyActor} actorRef
  */
 export async function prepareCombatRoll(rollData, actorRef) {
-    if (rollData.weapon.clip.value <= 0) {
+    if (rollData.weapon.isRanged && rollData.weapon.clip.value <= 0) {
         reportEmptyClip(rollData);
     } else {
         const html = await renderTemplate("systems/dark-heresy/template/dialog/combat-roll.hbs", rollData);

--- a/script/sheet/item.js
+++ b/script/sheet/item.js
@@ -8,9 +8,6 @@ export class DarkHeresyItemSheet extends ItemSheet {
         const data = await super.getData();
         data.enrichment = await this._handleEnrichment();
         data.system = data.data.system;
-        if (data.item.isWeapon) {
-            data.ammo = data.item.parent.itemTypes.ammunition;
-        }
         return data;
     }
 

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "id": "dark-heresy",
   "title": "Dark Heresy 2E",
   "description": "Unofficial Foundry VTT System for Dark Heresy 2nd Edition.",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "minimumCoreVersion" : 11,
   "compatibility" : {
     "minimum" : 11,
@@ -18,7 +18,8 @@
       "reddit": "u/mooman10" }, 
     { "name":"fredthedeadhead" },
     { "name":"Perfectro" }, 
-    { "name":"Vendare" },
+    { "name":"Vendare",
+	  "discord": "Vendare#4014",},
     { "name":"Silver292" },
     { "name":"Giddy" },
     { "name":"Dazzerix" },
@@ -68,7 +69,7 @@
   "secondaryTokenAttribute": null,
   "url": "https://github.com/Vendare/DarkHeresy2E-FoundryVTT",
   "socket": true,
-  "manifest": "https://github.com/Vendare/DarkHeresy2E-FoundryVTT/releases/download/4.3.1/system.json",
-  "download": "https://github.com/Vendare/DarkHeresy2E-FoundryVTT/releases/download/4.3.1/dark-heresy.zip",
+  "manifest": "https://github.com/Vendare/DarkHeresy2E-FoundryVTT/releases/download/4.3.2/system.json",
+  "download": "https://github.com/Vendare/DarkHeresy2E-FoundryVTT/releases/download/4.3.2/dark-heresy.zip",
   "license": "LICENSE.txt"
 }

--- a/template/chat/damage.hbs
+++ b/template/chat/damage.hbs
@@ -5,7 +5,7 @@
             <h3 class="separator damage-location" data-location={{location}}>{{localize location}}</h3>
             <div>
                 <p><strong>{{localize "CHAT.DAMAGE"}}:</strong> <span class="damage-total">{{damage.total}}</span> 
-                <strong class="damage-type">{{damageTypeShort ../damageType}}</strong>
+                <strong class="damage-type">{{damageTypeShort ../weapon.damageType}}</strong>
 	            </p>
 	        </div>
 	        <p><strong>{{localize "CHAT.PENETRATION"}}:</strong> <span class="damage-penetration">{{penetration}}</span></p>


### PR DESCRIPTION
Fixed #166 Rolls are now correctly added to the chatmessage so can be detected as a roll
Fixed #165 Twin-Linked Weapons now roll and correctly add the extra hit
Fixed #164  Items in the items tab could not be edited due to experimental code breaking when the items didn't have an owner
Fixed Melee Weapons without an Ammo Value prompting the reload message
Changed the Behavior of the Damage Roll Card. The indivdual rolls now only open on a double click