### PR TITLE
Feature/add ammo to weapons

### DIFF
--- a/less/sheet/actor/tab/gear.less
+++ b/less/sheet/actor/tab/gear.less
@@ -158,3 +158,9 @@
 .dark-heresy .gear .all-gear .item-list .items .gear {
     width: 100%;
 }
+
+.dark-heresy .gear .linked-item {
+    width: 100%;
+    text-align: left;
+    padding-left: 10px;
+}

--- a/script/common/roll.js
+++ b/script/common/roll.js
@@ -1,4 +1,4 @@
-import {PlaceableTemplate} from "./placeable-template.js";
+import { PlaceableTemplate } from "./placeable-template.js";
 
 /**
  * Roll a generic roll, and post the result to chat.
@@ -82,7 +82,7 @@ async function _computeCombatTarget(rollData) {
     }
     let psyModifier = 0;
     if (typeof rollData.psy !== "undefined" && typeof rollData.psy.useModifier !== "undefined" && rollData.psy.useModifier) {
-    // Set Current Psyrating to the allowed maximum if it is bigger
+        // Set Current Psyrating to the allowed maximum if it is bigger
         if (rollData.psy.value > rollData.psy.max) {
             rollData.psy.value = rollData.psy.max;
         }
@@ -95,11 +95,11 @@ async function _computeCombatTarget(rollData) {
     }
 
     let targetMods = rollData.target.modifier
-    + (rollData.aim?.val ? rollData.aim.val : 0)
-    + (rollData.rangeMod ? rollData.rangeMod : 0)
-    + (rollData.weapon?.traits?.twinLinked ? 20: 0)
-    + attackType
-    + psyModifier;
+        + (rollData.aim?.val ? rollData.aim.val : 0)
+        + (rollData.rangeMod ? rollData.rangeMod : 0)
+        + (rollData.weapon?.traits?.twinLinked ? 20 : 0)
+        + attackType
+        + psyModifier;
 
     rollData.target.final = _getRollTarget(targetMods, rollData.target.base);
 }
@@ -196,7 +196,7 @@ async function _rollDamage(rollData) {
     firstHit.location = firstLocation;
     rollData.damages.push(firstHit);
 
-    let additionalhits = rollData.numberOfHits -1;
+    let additionalhits = rollData.numberOfHits - 1;
 
     for (let i = 0; i < additionalhits; i++) {
         let additionalHit = await _computeDamage(
@@ -232,7 +232,7 @@ function _computeNumberOfHits(attackDos, evasionDos, attackType, shotsFired, wea
     let stormMod = weaponTraits.storm ? 2 : 1;
     let maxHits = attackType.maxHits * stormMod;
 
-    if (weaponTraits.twinLinked && attackDos >=2) {
+    if (weaponTraits.twinLinked && attackDos >= 2) {
         maxHits += 1;
         attackDos += attackType.hitMargin;
         if (shotsFired) shotsFired += 1;
@@ -351,7 +351,7 @@ async function _updateRangedAmmo(rollData) {
                     break;
                 }
             }
-            await weapon.update({"system.clip.value": rollData.weapon.clip.value});
+            await weapon.update({ "system.clip.value": rollData.weapon.clip.value });
         }
     }
 }

--- a/script/common/util.js
+++ b/script/common/util.js
@@ -45,9 +45,9 @@ export default class DarkHeresyUtil {
         let characteristic = this.getWeaponCharacteristic(actor, weaponItem);
         let rateOfFire;
         if (weaponItem.class === "melee") {
-            rateOfFire = {burst: characteristic.bonus, full: characteristic.bonus};
+            rateOfFire = { burst: characteristic.bonus, full: characteristic.bonus };
         } else {
-            rateOfFire = {burst: weaponItem.rateOfFire.burst, full: weaponItem.rateOfFire.full};
+            rateOfFire = { burst: weaponItem.rateOfFire.burst, full: weaponItem.rateOfFire.full };
         }
         let weaponTraits = this.extractWeaponTraits(weaponItem.special);
         let isMelee = weaponItem.class === "melee";
@@ -64,8 +64,8 @@ export default class DarkHeresyUtil {
             clip: weaponItem.clip,
             rateOfFire: rateOfFire,
             range: !isMelee ? weaponItem.range : 0,
-            damageFormula: weaponItem.damage + attributeMod + (weaponTraits.force ? "+PR": ""),
-            penetrationFormula: weaponItem.penetration + (weaponTraits.force ? "+PR" : ""),
+            damageFormula: weaponItem.damage + attributeMod + (weaponTraits.force ? "+PR" : "") + (weaponItem.system.ammoItem ? `+${weaponItem.system.ammoItem.system.effect.damage.modifier}` : ""),
+            penetrationFormula: weaponItem.penetration + (weaponTraits.force ? "+PR" : "") + (weaponItem.system.ammoItem ? `+${weaponItem.system.ammoItem.system.effect.penetration}` : ""),
             traits: weaponTraits,
             special: weaponItem.special
         });
@@ -77,8 +77,8 @@ export default class DarkHeresyUtil {
         let focusPowerTarget = this.getFocusPowerTarget(actor, power);
 
         let rollData = this.createCommonAttackRollData(actor, power);
-        rollData.target.base= focusPowerTarget.total;
-        rollData.target.modifier= power.focusPower.difficulty;
+        rollData.target.base = focusPowerTarget.total;
+        rollData.target.modifier = power.focusPower.difficulty;
         rollData.weapon = foundry.utils.mergeObject(rollData.weapon, {
             damageFormula: power.damage.formula,
             penetrationFormula: power.damage.penetration,
@@ -156,7 +156,7 @@ export default class DarkHeresyUtil {
 
 
     static extractWeaponTraits(traits) {
-    // These weapon traits never go above 9 or below 2
+        // These weapon traits never go above 9 or below 2
         return {
             accurate: this.hasNamedTrait(/(?<!in)Accurate/gi, traits),
             rfFace: this.extractNumberedTrait(/Vengeful.*\(\d\)/gi, traits), // The alternativ die face Righteous Fury is triggered on

--- a/script/dark-heresy.js
+++ b/script/dark-heresy.js
@@ -30,6 +30,7 @@ import Dh from "./common/config.js";
 
 // Import Helpers
 import * as chat from "./common/chat.js";
+import { registerDataModels } from "./setup/registerDataModels.js";
 
 Hooks.once("init", function() {
     CONFIG.Combat.initiative = { formula: "@initiative.base + @initiative.bonus", decimals: 0 };
@@ -71,6 +72,8 @@ Hooks.once("init", function() {
     Items.registerSheet("dark-heresy", SpecialAbilitySheet, { types: ["specialAbility"], makeDefault: true });
     Items.registerSheet("dark-heresy", TraitSheet, { types: ["trait"], makeDefault: true });
     Items.registerSheet("dark-heresy", AptitudeSheet, { types: ["aptitude"], makeDefault: true });
+
+    registerDataModels();
 
     initializeHandlebars();
 

--- a/script/data/item/ammunitionData.js
+++ b/script/data/item/ammunitionData.js
@@ -1,0 +1,52 @@
+import EquipmentItemData from "./equipmentItemData.js";
+
+const fields = foundry.data.fields;
+
+export default class AmmunitionData extends EquipmentItemData {
+
+    static defineSchema() {
+
+        const equipmentItemData = super.defineSchema();
+        return {
+            // Using destructuring to effectively append our additional data here
+            ...equipmentItemData,
+            quantity: new fields.NumberField({ initial: 0 }),
+            effect: new fields.SchemaField({
+                damage: new fields.SchemaField({
+                    modifier: new fields.NumberField({ initial: 0 }),
+                    type: new fields.StringField({ initial: "impact" })
+                }),
+                special: new fields.StringField({ initial: "" }),
+                penetration: new fields.StringField({ initial: "0" }),
+                attack: new fields.SchemaField({
+                    modifier: new fields.NumberField({ initial: 0 })
+                })
+            }),
+            weapon: new fields.StringField({ initial: "" }),
+            weaponId: new fields.StringField({ initial: "" })
+        };
+
+    }
+
+    prepareDerivedData() {
+        super.prepareDerivedData();
+
+        this.prepareWeaponFetch();
+
+    }
+
+    prepareWeaponFetch() {
+        // We only store a reference to the weapon, here we get the whole item and store it in memory only
+        // Weapons can only be connected to ammo for actor owned ammo
+        if (this.parent.actor && this.weaponId !== "") {
+            this.weaponItem = this.parent.actor.items.get(this.weaponId);
+            this.weapon = this.weaponItem.name;
+        }
+
+        if (this.parent.actor && this.weaponId === "") {
+            this.weaponItem = null;
+            this.weapon = "";
+        }
+    }
+
+}

--- a/script/data/item/equipmentItemData.js
+++ b/script/data/item/equipmentItemData.js
@@ -1,0 +1,12 @@
+const fields = foundry.data.fields;
+
+export default class EquipmentItemData extends foundry.abstract.TypeDataModel {
+    static defineSchema() {
+        return {
+            craftsmanship: new fields.StringField({ initial: "common" }),
+            description: new fields.StringField({ initial: "" }),
+            availability: new fields.StringField({ initial: "common" }),
+            weight: new fields.NumberField({ initial: 0 })
+        };
+    }
+}

--- a/script/data/item/weaponData.js
+++ b/script/data/item/weaponData.js
@@ -1,0 +1,45 @@
+import EquipmentItemData from "./equipmentItemData.js";
+
+const fields = foundry.data.fields;
+
+export default class WeaponData extends EquipmentItemData {
+
+    static defineSchema() {
+
+        const equipmentItemData = super.defineSchema();
+        return {
+            // Using destructuring to effectively append our additional data here
+            ...equipmentItemData,
+            class: new fields.StringField({ initial: "" }),
+            type: new fields.StringField({ initial: "" }),
+            range: new fields.NumberField({ initial: 0 }),
+            rateOfFire: new fields.SchemaField({
+                single: new fields.NumberField({ initial: 0 }),
+                burst: new fields.NumberField({ initial: 0 }),
+                full: new fields.NumberField({ initial: 0 })
+            }),
+            damage: new fields.StringField({ initial: "" }),
+            damageType: new fields.StringField({ initial: "impact" }),
+            penetration: new fields.StringField({ initial: "0" }),
+            clip: new fields.SchemaField({
+                max: new fields.NumberField({ initial: 0 }),
+                value: new fields.NumberField({ initial: 0 })
+            }),
+            reload: new fields.StringField({ initial: "Full" }),
+            special: new fields.StringField({ initial: "" }),
+            attack: new fields.NumberField({ initial: 0 }),
+            ammo: new fields.StringField({ initial: "" })
+        };
+
+    }
+
+    prepareDerivedData() {
+        super.prepareDerivedData();
+
+        if (this.ammo !== "") {
+            // load ammo
+        }
+
+    }
+
+}

--- a/script/data/item/weaponData.js
+++ b/script/data/item/weaponData.js
@@ -36,10 +36,16 @@ export default class WeaponData extends EquipmentItemData {
     prepareDerivedData() {
         super.prepareDerivedData();
 
-        if (this.ammo !== "") {
-            // load ammo
-        }
+        this.prepareAmmoFetch();
 
+    }
+
+    prepareAmmoFetch() {
+        // We only store a reference to the ammo, here we get the whole item and store it in memory only
+        // Ammo can only be connected to weapons for actor owned weapons
+        if (this.parent.actor && this.ammo !== "") {
+            this.ammoItem = this.parent.actor.items.get(this.ammo);
+        }
     }
 
 }

--- a/script/setup/registerDataModels.js
+++ b/script/setup/registerDataModels.js
@@ -1,0 +1,12 @@
+import WeaponData from "../data/item/weaponData.js";
+
+export const registerDataModels = () => {
+    foundry.utils.mergeObject(CONFIG.Actor.dataModels, {
+        // Stub for when Actors are moved to data models
+    });
+
+    foundry.utils.mergeObject(CONFIG.Item.dataModels, {
+        // The keys are the types defined in our template.json
+        weapon: WeaponData
+    });
+};

--- a/script/setup/registerDataModels.js
+++ b/script/setup/registerDataModels.js
@@ -1,3 +1,4 @@
+import AmmunitionData from "../data/item/ammunitionData.js";
 import WeaponData from "../data/item/weaponData.js";
 
 export const registerDataModels = () => {
@@ -7,6 +8,7 @@ export const registerDataModels = () => {
 
     foundry.utils.mergeObject(CONFIG.Item.dataModels, {
         // The keys are the types defined in our template.json
-        weapon: WeaponData
+        weapon: WeaponData,
+        ammunition: AmmunitionData
     });
 };

--- a/script/sheet/weapon.js
+++ b/script/sheet/weapon.js
@@ -14,7 +14,10 @@ export class WeaponSheet extends DarkHeresyItemSheet {
                     contentSelector: ".sheet-body",
                     initial: "stats"
                 }
-            ]
+            ],
+            dragDrop: [{
+                dropSelector: null
+            }]
         });
     }
 
@@ -26,5 +29,26 @@ export class WeaponSheet extends DarkHeresyItemSheet {
 
     activateListeners(html) {
         super.activateListeners(html);
+    }
+
+    _canDragDrop(selector) {
+        return true;
+    }
+
+    async _onDrop(event) {
+        let dragEventData = TextEditor.getDragEventData(event);
+        let item = fromUuidSync(dragEventData.uuid);
+
+        // We only want to allow drops on weapons that belong to an actor
+        if (!this.item.actor) return;
+
+        // It has to be ammunition from the same actor
+        if (item?.type === "ammunition" && item?.actor.uuid === this.item.actor.uuid) {
+            if (this.item.ammo !== "") {
+                // remove old ammo
+            }
+
+            this.item.update({ "system.ammo": item.id });
+        }
     }
 }

--- a/script/sheet/weapon.js
+++ b/script/sheet/weapon.js
@@ -44,10 +44,12 @@ export class WeaponSheet extends DarkHeresyItemSheet {
 
         // It has to be ammunition from the same actor
         if (item?.type === "ammunition" && item?.actor.uuid === this.item.actor.uuid) {
-            if (this.item.ammo !== "") {
-                // remove old ammo
+            if (this.item.system.ammo !== "") {
+                let oldAmmo = this.item.actor.items.get(this.item.system.ammo);
+                oldAmmo.update({ "system.weaponId": "" });
             }
 
+            item.update({ "system.weaponId": this.item.id });
             this.item.update({ "system.ammo": item.id });
         }
     }

--- a/template.json
+++ b/template.json
@@ -1218,24 +1218,7 @@
                 "source": ""
             }
         },
-        "ammunition": {
-            "templates": [
-                "equipment"
-            ],
-            "quantity": 0,
-            "effect": {
-                "damage": {
-                    "modifier": 0,
-                    "type": "impact"
-                },
-                "special": "",
-                "penetration": "",
-                "attack": {
-                    "modifier": 0
-                }
-            },
-            "weapon": ""
-        },
+        "ammunition": {},
         "armour": {
             "templates": [
                 "equipment"

--- a/template.json
+++ b/template.json
@@ -1,1245 +1,1369 @@
 {
-  "Actor": {
-    "types": [
-      "acolyte",
-      "npc"
-    ],
-    "templates": {
-      "characteristics": {
-        "characteristics": {
-          "weaponSkill": {
-            "label": "CHARACTERISTIC.WEAPON_SKILL",
-            "short": "WS",
-            "base": 0,
-            "advance": 0,
-            "unnatural": 0,
-            "aptitudes": ["Weapon Skill", "Offence"],
-            "cost": 0,
-            "damage": 0
-          },
-          "ballisticSkill": {
-            "label": "CHARACTERISTIC.BALLISTIC_SKILL",
-            "short": "BS",
-            "base": 0,
-            "advance": 0,
-            "unnatural": 0,
-            "aptitudes": ["Ballistic Skill", "Finesse"],
-            "cost": 0,
-            "damage": 0
-          },
-          "strength": {
-            "label": "CHARACTERISTIC.STRENGTH",
-            "short": "S",
-            "base": 0,
-            "advance": 0,
-            "unnatural": 0,
-            "aptitudes": ["Strength", "Offence"],
-            "cost": 0,
-            "damage": 0
-          },
-          "toughness": {
-            "label": "CHARACTERISTIC.TOUGHNESS",
-            "short": "T",
-            "base": 0,
-            "advance": 0,
-            "unnatural": 0,
-            "aptitudes": ["Toughness", "Defence"],
-            "cost": 0,
-            "damage": 0
-          },
-          "agility": {
-            "label": "CHARACTERISTIC.AGILITY",
-            "short": "Ag",
-            "base": 0,
-            "advance": 0,
-            "unnatural": 0,
-            "aptitudes": ["Agility", "Finesse"],
-            "cost": 0,
-            "damage": 0
-          },
-          "intelligence": {
-            "label": "CHARACTERISTIC.INTELLIGENCE",
-            "short": "Int",
-            "base": 0,
-            "advance": 0,
-            "unnatural": 0,
-            "aptitudes": ["Intelligence", "Knowledge"],
-            "cost": 0,
-            "damage": 0
-          },
-          "perception": {
-            "label": "CHARACTERISTIC.PERCEPTION",
-            "short": "Per",
-            "base": 0,
-            "advance": 0,
-            "unnatural": 0,
-            "aptitudes": ["Perception", "Fieldcraft"],
-            "cost": 0,
-            "damage": 0
-          },
-          "willpower": {
-            "label": "CHARACTERISTIC.WILLPOWER",
-            "short": "WP",
-            "base": 0,
-            "advance": 0,
-            "unnatural": 0,
-            "aptitudes": ["Willpower", "Psyker"],
-            "cost": 0,
-            "damage": 0
-          },
-          "fellowship": {
-            "label": "CHARACTERISTIC.FELLOWSHIP",
-            "short": "Fel",
-            "base": 0,
-            "advance": 0,
-            "unnatural": 0,
-            "aptitudes": ["Fellowship", "Social"],
-            "cost": 0,
-            "damage": 0
-          },
-          "influence": {
-            "label": "CHARACTERISTIC.INFLUENCE",
-            "short": "Inf",
-            "base": 0,
-            "advance": 0,
-            "unnatural": 0,
-            "aptitudes": [],
-            "cost": 0,
-            "damage": 0
-          }
-        }
-      },
-      "skills": {
-        "skills": {
-          "acrobatics": {
-            "label": "SKILL.ACROBATICS",
-            "characteristics": [
-              "Ag",
-              "S"
-            ],
-            "advance": -20,
-            "isSpecialist": false,
-            "specialities": {},
-            "aptitudes": ["Agility", "General"],
-            "starter": false,
-            "cost": 0
-          },
-          "athletics": {
-            "label": "SKILL.ATHLETICS",
-            "characteristics": [
-              "S",
-              "T"
-            ],
-            "advance": -20,
-            "isSpecialist": false,
-            "specialities": {},
-            "aptitudes": ["Strength", "General"],
-            "starter": false,
-            "cost": 0
-          },
-          "awareness": {
-            "label": "SKILL.AWARENESS",
-            "characteristics": [
-              "Per",
-              "Fel",
-              "Int"
-            ],
-            "advance": -20,
-            "isSpecialist": false,
-            "specialities": {},
-            "aptitudes": ["Perception", "Fieldcraft"],
-            "starter": false,
-            "cost": 0
-          },
-          "charm": {
-            "label": "SKILL.CHARM",
-            "characteristics": [
-              "Fel",
-              "Inf"
-            ],
-            "advance": -20,
-            "isSpecialist": false,
-            "specialities": {},
-            "aptitudes": ["Fellowship", "Social"],
-            "starter": false,
-            "cost": 0
-          },
-          "command": {
-            "label": "SKILL.COMMAND",
-            "characteristics": [
-              "Fel",
-              "Int",
-              "S",
-              "WP"
-            ],
-            "advance": -20,
-            "isSpecialist": false,
-            "specialities": {},
-            "aptitudes": ["Fellowship", "Leadership"],
-            "starter": false,
-            "cost": 0
-          },
-          "commerce": {
-            "label": "SKILL.COMMERCE",
-            "characteristics": [
-              "Int",
-              "Fel"
-            ],
-            "advance": -20,
-            "isSpecialist": false,
-            "specialities": {},
-            "aptitudes": ["Intelligence", "Knowledge"],
-            "starter": false,
-            "cost": 0
-          },
-          "commonLore": {
-            "label": "SKILL.COMMON_LORE",
-            "characteristics": [
-              "Int",
-              "Fel"
-            ],
-            "advance": -20,
-            "isSpecialist": true,
-            "aptitudes": ["Intelligence", "Knowledge"],
-            "specialities": {
-              "adeptaSororitas": {
-                "label": "Adepta Sororitas",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "adeptusArbites": {
-                "label": "Adeptus Arbites",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "adeptusAstartes": {
-                "label": "Adeptus Astartes",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "adeptusAstraTelepathica": {
-                "label": "Adeptus Astra Telepathica",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "adeptusMechanicus": {
-                "label": "Adeptus Mechanicus",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "administratum": {
-                "label": "Administratum",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "askellonSector": {
-                "label": "Askellon Sector",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "chartistCaptains": {
-                "label": "Chartist Captains",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "collegiaTitanicu": {
-                "label": "Collegia Titanicu",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "ecclesiarchy": {
-                "label": "Ecclesiarchy",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "imperialCreed": {
-                "label": "Imperial Creed",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "imperialGuard": {
-                "label": "Imperial Guard",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "imperialNavy": {
-                "label": "Imperial Navy",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "imperium": {
-                "label": "Imperium",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "navigators": {
-                "label": "Navigators",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "planetaryDefenceForces": {
-                "label": "Planetary Defence Forces",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "rogueTraders": {
-                "label": "Rogue Traders",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "scholaProgenium": {
-                "label": "Schola Progenium",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "tech": {
-                "label": "Tech",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "underworld": {
-                "label": "Underworld",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "war": {
-                "label": "War",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              }
+    "Actor": {
+        "types": [
+            "acolyte",
+            "npc"
+        ],
+        "templates": {
+            "characteristics": {
+                "characteristics": {
+                    "weaponSkill": {
+                        "label": "CHARACTERISTIC.WEAPON_SKILL",
+                        "short": "WS",
+                        "base": 0,
+                        "advance": 0,
+                        "unnatural": 0,
+                        "aptitudes": [
+                            "Weapon Skill",
+                            "Offence"
+                        ],
+                        "cost": 0,
+                        "damage": 0
+                    },
+                    "ballisticSkill": {
+                        "label": "CHARACTERISTIC.BALLISTIC_SKILL",
+                        "short": "BS",
+                        "base": 0,
+                        "advance": 0,
+                        "unnatural": 0,
+                        "aptitudes": [
+                            "Ballistic Skill",
+                            "Finesse"
+                        ],
+                        "cost": 0,
+                        "damage": 0
+                    },
+                    "strength": {
+                        "label": "CHARACTERISTIC.STRENGTH",
+                        "short": "S",
+                        "base": 0,
+                        "advance": 0,
+                        "unnatural": 0,
+                        "aptitudes": [
+                            "Strength",
+                            "Offence"
+                        ],
+                        "cost": 0,
+                        "damage": 0
+                    },
+                    "toughness": {
+                        "label": "CHARACTERISTIC.TOUGHNESS",
+                        "short": "T",
+                        "base": 0,
+                        "advance": 0,
+                        "unnatural": 0,
+                        "aptitudes": [
+                            "Toughness",
+                            "Defence"
+                        ],
+                        "cost": 0,
+                        "damage": 0
+                    },
+                    "agility": {
+                        "label": "CHARACTERISTIC.AGILITY",
+                        "short": "Ag",
+                        "base": 0,
+                        "advance": 0,
+                        "unnatural": 0,
+                        "aptitudes": [
+                            "Agility",
+                            "Finesse"
+                        ],
+                        "cost": 0,
+                        "damage": 0
+                    },
+                    "intelligence": {
+                        "label": "CHARACTERISTIC.INTELLIGENCE",
+                        "short": "Int",
+                        "base": 0,
+                        "advance": 0,
+                        "unnatural": 0,
+                        "aptitudes": [
+                            "Intelligence",
+                            "Knowledge"
+                        ],
+                        "cost": 0,
+                        "damage": 0
+                    },
+                    "perception": {
+                        "label": "CHARACTERISTIC.PERCEPTION",
+                        "short": "Per",
+                        "base": 0,
+                        "advance": 0,
+                        "unnatural": 0,
+                        "aptitudes": [
+                            "Perception",
+                            "Fieldcraft"
+                        ],
+                        "cost": 0,
+                        "damage": 0
+                    },
+                    "willpower": {
+                        "label": "CHARACTERISTIC.WILLPOWER",
+                        "short": "WP",
+                        "base": 0,
+                        "advance": 0,
+                        "unnatural": 0,
+                        "aptitudes": [
+                            "Willpower",
+                            "Psyker"
+                        ],
+                        "cost": 0,
+                        "damage": 0
+                    },
+                    "fellowship": {
+                        "label": "CHARACTERISTIC.FELLOWSHIP",
+                        "short": "Fel",
+                        "base": 0,
+                        "advance": 0,
+                        "unnatural": 0,
+                        "aptitudes": [
+                            "Fellowship",
+                            "Social"
+                        ],
+                        "cost": 0,
+                        "damage": 0
+                    },
+                    "influence": {
+                        "label": "CHARACTERISTIC.INFLUENCE",
+                        "short": "Inf",
+                        "base": 0,
+                        "advance": 0,
+                        "unnatural": 0,
+                        "aptitudes": [],
+                        "cost": 0,
+                        "damage": 0
+                    }
+                }
+            },
+            "skills": {
+                "skills": {
+                    "acrobatics": {
+                        "label": "SKILL.ACROBATICS",
+                        "characteristics": [
+                            "Ag",
+                            "S"
+                        ],
+                        "advance": -20,
+                        "isSpecialist": false,
+                        "specialities": {},
+                        "aptitudes": [
+                            "Agility",
+                            "General"
+                        ],
+                        "starter": false,
+                        "cost": 0
+                    },
+                    "athletics": {
+                        "label": "SKILL.ATHLETICS",
+                        "characteristics": [
+                            "S",
+                            "T"
+                        ],
+                        "advance": -20,
+                        "isSpecialist": false,
+                        "specialities": {},
+                        "aptitudes": [
+                            "Strength",
+                            "General"
+                        ],
+                        "starter": false,
+                        "cost": 0
+                    },
+                    "awareness": {
+                        "label": "SKILL.AWARENESS",
+                        "characteristics": [
+                            "Per",
+                            "Fel",
+                            "Int"
+                        ],
+                        "advance": -20,
+                        "isSpecialist": false,
+                        "specialities": {},
+                        "aptitudes": [
+                            "Perception",
+                            "Fieldcraft"
+                        ],
+                        "starter": false,
+                        "cost": 0
+                    },
+                    "charm": {
+                        "label": "SKILL.CHARM",
+                        "characteristics": [
+                            "Fel",
+                            "Inf"
+                        ],
+                        "advance": -20,
+                        "isSpecialist": false,
+                        "specialities": {},
+                        "aptitudes": [
+                            "Fellowship",
+                            "Social"
+                        ],
+                        "starter": false,
+                        "cost": 0
+                    },
+                    "command": {
+                        "label": "SKILL.COMMAND",
+                        "characteristics": [
+                            "Fel",
+                            "Int",
+                            "S",
+                            "WP"
+                        ],
+                        "advance": -20,
+                        "isSpecialist": false,
+                        "specialities": {},
+                        "aptitudes": [
+                            "Fellowship",
+                            "Leadership"
+                        ],
+                        "starter": false,
+                        "cost": 0
+                    },
+                    "commerce": {
+                        "label": "SKILL.COMMERCE",
+                        "characteristics": [
+                            "Int",
+                            "Fel"
+                        ],
+                        "advance": -20,
+                        "isSpecialist": false,
+                        "specialities": {},
+                        "aptitudes": [
+                            "Intelligence",
+                            "Knowledge"
+                        ],
+                        "starter": false,
+                        "cost": 0
+                    },
+                    "commonLore": {
+                        "label": "SKILL.COMMON_LORE",
+                        "characteristics": [
+                            "Int",
+                            "Fel"
+                        ],
+                        "advance": -20,
+                        "isSpecialist": true,
+                        "aptitudes": [
+                            "Intelligence",
+                            "Knowledge"
+                        ],
+                        "specialities": {
+                            "adeptaSororitas": {
+                                "label": "Adepta Sororitas",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "adeptusArbites": {
+                                "label": "Adeptus Arbites",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "adeptusAstartes": {
+                                "label": "Adeptus Astartes",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "adeptusAstraTelepathica": {
+                                "label": "Adeptus Astra Telepathica",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "adeptusMechanicus": {
+                                "label": "Adeptus Mechanicus",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "administratum": {
+                                "label": "Administratum",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "askellonSector": {
+                                "label": "Askellon Sector",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "chartistCaptains": {
+                                "label": "Chartist Captains",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "collegiaTitanicu": {
+                                "label": "Collegia Titanicu",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "ecclesiarchy": {
+                                "label": "Ecclesiarchy",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "imperialCreed": {
+                                "label": "Imperial Creed",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "imperialGuard": {
+                                "label": "Imperial Guard",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "imperialNavy": {
+                                "label": "Imperial Navy",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "imperium": {
+                                "label": "Imperium",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "navigators": {
+                                "label": "Navigators",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "planetaryDefenceForces": {
+                                "label": "Planetary Defence Forces",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "rogueTraders": {
+                                "label": "Rogue Traders",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "scholaProgenium": {
+                                "label": "Schola Progenium",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "tech": {
+                                "label": "Tech",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "underworld": {
+                                "label": "Underworld",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "war": {
+                                "label": "War",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            }
+                        }
+                    },
+                    "deceive": {
+                        "label": "SKILL.DECEIVE",
+                        "characteristics": [
+                            "Fel",
+                            "Int"
+                        ],
+                        "advance": -20,
+                        "isSpecialist": false,
+                        "specialities": {},
+                        "aptitudes": [
+                            "Fellowship",
+                            "Social"
+                        ],
+                        "starter": false,
+                        "cost": 0
+                    },
+                    "dodge": {
+                        "label": "SKILL.DODGE",
+                        "characteristics": [
+                            "Ag"
+                        ],
+                        "advance": -20,
+                        "isSpecialist": false,
+                        "specialities": {},
+                        "aptitudes": [
+                            "Agility",
+                            "Defence"
+                        ],
+                        "starter": false,
+                        "cost": 0
+                    },
+                    "forbiddenLore": {
+                        "label": "SKILL.FORBIDDEN_LORE",
+                        "characteristics": [
+                            "Int",
+                            "Fel"
+                        ],
+                        "advance": -20,
+                        "isSpecialist": true,
+                        "aptitudes": [
+                            "Intelligence",
+                            "Knowledge"
+                        ],
+                        "specialities": {
+                            "archaeotech": {
+                                "label": "Archaeotech",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "chaosSpaceMarines": {
+                                "label": "Chaos Space Marines",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "criminalCartelsAndSmugglers": {
+                                "label": "Criminal Cartels and Smugglers",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "daemonology": {
+                                "label": "Daemonology",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "heresy": {
+                                "label": "Heresy",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "theHorusHeresyAndTheLongWar": {
+                                "label": "The Horus Heresy and the Long War",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "inquisition": {
+                                "label": "Inquisition",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "mutants": {
+                                "label": "Mutants",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "officioAssassinorum": {
+                                "label": "Officio Assassinorum",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "pirates": {
+                                "label": "Pirates",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "psykers": {
+                                "label": "Psykers",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "theWarp": {
+                                "label": "The Warp",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "xenos": {
+                                "label": "Xenos",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            }
+                        }
+                    },
+                    "inquiry": {
+                        "label": "SKILL.INQUIRY",
+                        "characteristics": [
+                            "Fel",
+                            "Int",
+                            "Per"
+                        ],
+                        "advance": -20,
+                        "isSpecialist": false,
+                        "specialities": {},
+                        "aptitudes": [
+                            "Fellowship",
+                            "Social"
+                        ],
+                        "starter": false,
+                        "cost": 0
+                    },
+                    "interrogation": {
+                        "label": "SKILL.INTERROGATION",
+                        "characteristics": [
+                            "WP",
+                            "Fel"
+                        ],
+                        "advance": -20,
+                        "isSpecialist": false,
+                        "specialities": {},
+                        "aptitudes": [
+                            "Willpower",
+                            "Social"
+                        ],
+                        "starter": false,
+                        "cost": 0
+                    },
+                    "intimidate": {
+                        "label": "SKILL.INTIMIDATE",
+                        "characteristics": [
+                            "S",
+                            "WP"
+                        ],
+                        "advance": -20,
+                        "isSpecialist": false,
+                        "specialities": {},
+                        "aptitudes": [
+                            "Strength",
+                            "Social"
+                        ],
+                        "starter": false,
+                        "cost": 0
+                    },
+                    "linguistics": {
+                        "label": "SKILL.LINGUISTICS",
+                        "characteristics": [
+                            "Int",
+                            "Fel"
+                        ],
+                        "advance": -20,
+                        "isSpecialist": true,
+                        "aptitudes": [
+                            "Intelligence",
+                            "General"
+                        ],
+                        "specialities": {
+                            "chapterRunes": {
+                                "label": "Chapter Runes",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "chaosMarks": {
+                                "label": "Chaos Marks",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "eldar": {
+                                "label": "Eldar",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "highGothic": {
+                                "label": "High Gothic",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "imperialCodes": {
+                                "label": "Imperial Codes",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "lowGothic": {
+                                "label": "Low Gothic",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "mercenary": {
+                                "label": "Mercenary",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "necrontyr": {
+                                "label": "Necrontyr",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "ork": {
+                                "label": "Ork",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "technaLingua": {
+                                "label": "Techna-Lingua",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "tau": {
+                                "label": "Tau",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "underworld": {
+                                "label": "Underworld",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "xenosMarkings": {
+                                "label": "Xenos Markings",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            }
+                        }
+                    },
+                    "logic": {
+                        "label": "SKILL.LOGIC",
+                        "characteristics": [
+                            "Int",
+                            "Ag"
+                        ],
+                        "advance": -20,
+                        "isSpecialist": false,
+                        "specialities": {},
+                        "aptitudes": [
+                            "Intelligence",
+                            "Knowledge"
+                        ],
+                        "starter": false,
+                        "cost": 0
+                    },
+                    "medicae": {
+                        "label": "SKILL.MEDICAE",
+                        "characteristics": [
+                            "Int",
+                            "Ag",
+                            "Per"
+                        ],
+                        "advance": -20,
+                        "isSpecialist": false,
+                        "specialities": {},
+                        "aptitudes": [
+                            "Intelligence",
+                            "Fieldcraft"
+                        ],
+                        "starter": false,
+                        "cost": 0
+                    },
+                    "navigate": {
+                        "label": "SKILL.NAVIGATE",
+                        "characteristics": [
+                            "Int",
+                            "Per"
+                        ],
+                        "advance": -20,
+                        "isSpecialist": true,
+                        "aptitudes": [
+                            "Intelligence",
+                            "Fieldcraft"
+                        ],
+                        "specialities": {
+                            "surface": {
+                                "label": "Surface",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "stellar": {
+                                "label": "Stellar",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "warp": {
+                                "label": "Warp",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            }
+                        }
+                    },
+                    "operate": {
+                        "label": "SKILL.OPERATE",
+                        "characteristics": [
+                            "Ag",
+                            "Int"
+                        ],
+                        "advance": -20,
+                        "isSpecialist": true,
+                        "aptitudes": [
+                            "Agility",
+                            "Fieldcraft"
+                        ],
+                        "specialities": {
+                            "surface": {
+                                "label": "Surface",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "aeronautica": {
+                                "label": "Aeronautica",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "voidship": {
+                                "label": "Voidship",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            }
+                        }
+                    },
+                    "parry": {
+                        "label": "SKILL.PARRY",
+                        "characteristics": [
+                            "WS"
+                        ],
+                        "advance": -20,
+                        "isSpecialist": false,
+                        "specialities": {},
+                        "aptitudes": [
+                            "Weapon Skill",
+                            "Defence"
+                        ],
+                        "starter": false,
+                        "cost": 0
+                    },
+                    "psyniscience": {
+                        "label": "SKILL.PSYNISCIENCE",
+                        "characteristics": [
+                            "Per",
+                            "WP"
+                        ],
+                        "advance": -20,
+                        "isSpecialist": false,
+                        "specialities": {},
+                        "aptitudes": [
+                            "Perception",
+                            "Psyker"
+                        ],
+                        "starter": false,
+                        "cost": 0
+                    },
+                    "scholasticLore": {
+                        "label": "SKILL.SCHOLASTIC_LORE",
+                        "characteristics": [
+                            "Int",
+                            "Fel"
+                        ],
+                        "advance": -20,
+                        "isSpecialist": true,
+                        "aptitudes": [
+                            "Intelligence",
+                            "Knowledge"
+                        ],
+                        "specialities": {
+                            "astromancy": {
+                                "label": "Astromancy",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "beasts": {
+                                "label": "Beasts",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "bureaucracy": {
+                                "label": "Bureaucracy",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "chymistry": {
+                                "label": "Chymistry",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "cryptology": {
+                                "label": "Cryptology",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "heraldry": {
+                                "label": "Heraldry",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "imperialWarrants": {
+                                "label": "Imperial Warrants",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "judgement": {
+                                "label": "Judgement",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "legend": {
+                                "label": "Legend",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "numerology": {
+                                "label": "Numerology",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "occult": {
+                                "label": "Occult",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "philosophy": {
+                                "label": "Philosophy",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "tacticaImperialis": {
+                                "label": "Tactica Imperialis",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            }
+                        }
+                    },
+                    "scrutiny": {
+                        "label": "SKILL.SCRUTINY",
+                        "characteristics": [
+                            "Per",
+                            "Fel"
+                        ],
+                        "advance": -20,
+                        "isSpecialist": false,
+                        "specialities": {},
+                        "aptitudes": [
+                            "Perception",
+                            "General"
+                        ],
+                        "starter": false,
+                        "cost": 0
+                    },
+                    "security": {
+                        "label": "SKILL.SECURITY",
+                        "characteristics": [
+                            "Int",
+                            "Ag"
+                        ],
+                        "advance": -20,
+                        "isSpecialist": false,
+                        "specialities": {},
+                        "aptitudes": [
+                            "Intelligence",
+                            "Tech"
+                        ],
+                        "starter": false,
+                        "cost": 0
+                    },
+                    "sleightOfHand": {
+                        "label": "SKILL.SLEIGHT_OF_HAND",
+                        "characteristics": [
+                            "Ag",
+                            "Int"
+                        ],
+                        "advance": -20,
+                        "isSpecialist": false,
+                        "specialities": {},
+                        "aptitudes": [
+                            "Agility",
+                            "Knowledge"
+                        ],
+                        "starter": false,
+                        "cost": 0
+                    },
+                    "stealth": {
+                        "label": "SKILL.STEALTH",
+                        "characteristics": [
+                            "Ag",
+                            "Per"
+                        ],
+                        "advance": -20,
+                        "isSpecialist": false,
+                        "specialities": {},
+                        "aptitudes": [
+                            "Agility",
+                            "Fieldcraft"
+                        ],
+                        "starter": false,
+                        "cost": 0
+                    },
+                    "survival": {
+                        "label": "SKILL.SURVIVAL",
+                        "characteristics": [
+                            "Per",
+                            "Ag",
+                            "Int"
+                        ],
+                        "advance": -20,
+                        "isSpecialist": false,
+                        "specialities": {},
+                        "aptitudes": [
+                            "Perception",
+                            "Fieldcraft"
+                        ],
+                        "starter": false,
+                        "cost": 0
+                    },
+                    "techUse": {
+                        "label": "SKILL.TECH_USE",
+                        "characteristics": [
+                            "Int",
+                            "Ag"
+                        ],
+                        "advance": -20,
+                        "isSpecialist": false,
+                        "specialities": {},
+                        "aptitudes": [
+                            "Intelligence",
+                            "Tech"
+                        ],
+                        "starter": false,
+                        "cost": 0
+                    },
+                    "trade": {
+                        "label": "SKILL.TRADE",
+                        "characteristics": [
+                            "Int",
+                            "Ag",
+                            "Fel"
+                        ],
+                        "advance": -20,
+                        "isSpecialist": true,
+                        "aptitudes": [
+                            "Intelligence",
+                            "General"
+                        ],
+                        "specialities": {
+                            "agri": {
+                                "label": "Agri",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "archaeologist": {
+                                "label": "Archaeologist",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "armourer": {
+                                "label": "Armourer",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "astrographer": {
+                                "label": "Astrographer",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "chymist": {
+                                "label": "Chymist",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "cryptographer": {
+                                "label": "Cryptographer",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "cook": {
+                                "label": "Cook",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "explorator": {
+                                "label": "Explorator",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "linguist": {
+                                "label": "Linguist",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "loremancer": {
+                                "label": "Loremancer",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "morticator": {
+                                "label": "Morticator",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "performancer": {
+                                "label": "Performancer",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "prospector": {
+                                "label": "Prospector",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "scrimshawer": {
+                                "label": "Scrimshawer",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "sculptor": {
+                                "label": "Sculptor",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "shipwright": {
+                                "label": "Shipwright",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "soothsayer": {
+                                "label": "Soothsayer",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "technomat": {
+                                "label": "Technomat",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            },
+                            "voidfarer": {
+                                "label": "Voidfarer",
+                                "advance": -20,
+                                "starter": false,
+                                "cost": 0
+                            }
+                        }
+                    }
+                }
+            },
+            "initiative": {
+                "initiative": {
+                    "characteristic": "agility",
+                    "base": "1d10"
+                }
+            },
+            "wounds": {
+                "wounds": {
+                    "max": 0,
+                    "value": 0,
+                    "critical": 0
+                }
+            },
+            "fatigue": {
+                "fatigue": {
+                    "max": 0,
+                    "value": 0
+                }
+            },
+            "fate": {
+                "fate": {
+                    "max": 0,
+                    "value": 0
+                }
+            },
+            "psy": {
+                "psy": {
+                    "rating": 0,
+                    "sustained": 0,
+                    "class": "bound",
+                    "cost": 0
+                }
             }
-          },
-          "deceive": {
-            "label": "SKILL.DECEIVE",
-            "characteristics": [
-              "Fel",
-              "Int"
-            ],
-            "advance": -20,
-            "isSpecialist": false,
-            "specialities": {},
-            "aptitudes": ["Fellowship", "Social"],
-            "starter": false,
-            "cost": 0
-          },
-          "dodge": {
-            "label": "SKILL.DODGE",
-            "characteristics": [
-              "Ag"
-            ],
-            "advance": -20,
-            "isSpecialist": false,
-            "specialities": {},
-            "aptitudes": ["Agility", "Defence"],
-            "starter": false,
-            "cost": 0
-          },
-          "forbiddenLore": {
-            "label": "SKILL.FORBIDDEN_LORE",
-            "characteristics": [
-              "Int",
-              "Fel"
-            ],
-            "advance": -20,
-            "isSpecialist": true,
-            "aptitudes": ["Intelligence", "Knowledge"],
-            "specialities": {
-              "archaeotech": {
-                "label": "Archaeotech",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "chaosSpaceMarines": {
-                "label": "Chaos Space Marines",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "criminalCartelsAndSmugglers": {
-                "label": "Criminal Cartels and Smugglers",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "daemonology": {
-                "label": "Daemonology",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "heresy": {
-                "label": "Heresy",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "theHorusHeresyAndTheLongWar": {
-                "label": "The Horus Heresy and the Long War",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "inquisition": {
-                "label": "Inquisition",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "mutants": {
-                "label": "Mutants",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "officioAssassinorum": {
-                "label": "Officio Assassinorum",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "pirates": {
-                "label": "Pirates",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "psykers": {
-                "label": "Psykers",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "theWarp": {
-                "label": "The Warp",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "xenos": {
-                "label": "Xenos",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              }
-            }
-          },
-          "inquiry": {
-            "label": "SKILL.INQUIRY",
-            "characteristics": [
-              "Fel",
-              "Int",
-              "Per"
-            ],
-            "advance": -20,
-            "isSpecialist": false,
-            "specialities": {},
-            "aptitudes": ["Fellowship", "Social"],
-            "starter": false,
-            "cost": 0
-          },
-          "interrogation": {
-            "label": "SKILL.INTERROGATION",
-            "characteristics": [
-              "WP",
-              "Fel"
-            ],
-            "advance": -20,
-            "isSpecialist": false,
-            "specialities": {},
-            "aptitudes": ["Willpower", "Social"],
-            "starter": false,
-            "cost": 0
-          },
-          "intimidate": {
-            "label": "SKILL.INTIMIDATE",
-            "characteristics": [
-              "S",
-              "WP"
-            ],
-            "advance": -20,
-            "isSpecialist": false,
-            "specialities": {},
-            "aptitudes": ["Strength", "Social"],
-            "starter": false,
-            "cost": 0
-          },
-          "linguistics": {
-            "label": "SKILL.LINGUISTICS",
-            "characteristics": [
-              "Int",
-              "Fel"
-            ],
-            "advance": -20,
-            "isSpecialist": true,
-            "aptitudes": ["Intelligence", "General"],
-            "specialities": {
-              "chapterRunes": {
-                "label": "Chapter Runes",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "chaosMarks": {
-                "label": "Chaos Marks",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "eldar": {
-                "label": "Eldar",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "highGothic": {
-                "label": "High Gothic",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "imperialCodes": {
-                "label": "Imperial Codes",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "lowGothic": {
-                "label": "Low Gothic",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "mercenary": {
-                "label": "Mercenary",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "necrontyr": {
-                "label": "Necrontyr",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "ork": {
-                "label": "Ork",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "technaLingua": {
-                "label": "Techna-Lingua",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "tau": {
-                "label": "Tau",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "underworld": {
-                "label": "Underworld",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "xenosMarkings": {
-                "label": "Xenos Markings",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              }
-            }
-          },
-          "logic": {
-            "label": "SKILL.LOGIC",
-            "characteristics": [
-              "Int",
-              "Ag"
-            ],
-            "advance": -20,
-            "isSpecialist": false,
-            "specialities": {},
-            "aptitudes": ["Intelligence", "Knowledge"],
-            "starter": false,
-            "cost": 0
-          },
-          "medicae": {
-            "label": "SKILL.MEDICAE",
-            "characteristics": [
-              "Int",
-              "Ag",
-              "Per"
-            ],
-            "advance": -20,
-            "isSpecialist": false,
-            "specialities": {},
-            "aptitudes": ["Intelligence", "Fieldcraft"],
-            "starter": false,
-            "cost": 0
-          },
-          "navigate": {
-            "label": "SKILL.NAVIGATE",
-            "characteristics": [
-              "Int",
-              "Per"
-            ],
-            "advance": -20,
-            "isSpecialist": true,
-            "aptitudes": ["Intelligence", "Fieldcraft"],
-            "specialities": {
-              "surface": {
-                "label": "Surface",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "stellar": {
-                "label": "Stellar",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "warp": {
-                "label": "Warp",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              }
-            }
-          },
-          "operate": {
-            "label": "SKILL.OPERATE",
-            "characteristics": [
-              "Ag",
-              "Int"
-            ],
-            "advance": -20,
-            "isSpecialist": true,
-            "aptitudes": ["Agility", "Fieldcraft"],
-            "specialities": {
-              "surface": {
-                "label": "Surface",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "aeronautica": {
-                "label": "Aeronautica",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "voidship": {
-                "label": "Voidship",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              }
-            }
-          },
-          "parry": {
-            "label": "SKILL.PARRY",
-            "characteristics": [
-              "WS"
-            ],
-            "advance": -20,
-            "isSpecialist": false,
-            "specialities": {},
-            "aptitudes": ["Weapon Skill", "Defence"],
-            "starter": false,
-            "cost": 0
-          },
-          "psyniscience": {
-            "label": "SKILL.PSYNISCIENCE",
-            "characteristics": [
-              "Per",
-              "WP"
-            ],
-            "advance": -20,
-            "isSpecialist": false,
-            "specialities": {},
-            "aptitudes": ["Perception", "Psyker"],
-            "starter": false,
-            "cost": 0
-          },
-          "scholasticLore": {
-            "label": "SKILL.SCHOLASTIC_LORE",
-            "characteristics": [
-              "Int",
-              "Fel"
-            ],
-            "advance": -20,
-            "isSpecialist": true,
-            "aptitudes": ["Intelligence", "Knowledge"],
-            "specialities": {
-              "astromancy": {
-                "label": "Astromancy",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "beasts": {
-                "label": "Beasts",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "bureaucracy": {
-                "label": "Bureaucracy",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "chymistry": {
-                "label": "Chymistry",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "cryptology": {
-                "label": "Cryptology",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "heraldry": {
-                "label": "Heraldry",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "imperialWarrants": {
-                "label": "Imperial Warrants",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "judgement": {
-                "label": "Judgement",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "legend": {
-                "label": "Legend",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "numerology": {
-                "label": "Numerology",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "occult": {
-                "label": "Occult",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "philosophy": {
-                "label": "Philosophy",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "tacticaImperialis": {
-                "label": "Tactica Imperialis",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              }
-            }
-          },
-          "scrutiny": {
-            "label": "SKILL.SCRUTINY",
-            "characteristics": [
-              "Per",
-              "Fel"
-            ],
-            "advance": -20,
-            "isSpecialist": false,
-            "specialities": {},
-            "aptitudes": ["Perception", "General"],
-            "starter": false,
-            "cost": 0
-          },
-          "security": {
-            "label": "SKILL.SECURITY",
-            "characteristics": [
-              "Int",
-              "Ag"
-            ],
-            "advance": -20,
-            "isSpecialist": false,
-            "specialities": {},
-            "aptitudes": ["Intelligence", "Tech"],
-            "starter": false,
-            "cost": 0
-          },
-          "sleightOfHand": {
-            "label": "SKILL.SLEIGHT_OF_HAND",
-            "characteristics": [
-              "Ag",
-              "Int"
-            ],
-            "advance": -20,
-            "isSpecialist": false,
-            "specialities": {},
-            "aptitudes": ["Agility", "Knowledge"],
-            "starter": false,
-            "cost": 0
-          },
-          "stealth": {
-            "label": "SKILL.STEALTH",
-            "characteristics": [
-              "Ag",
-              "Per"
-            ],
-            "advance": -20,
-            "isSpecialist": false,
-            "specialities": {},
-            "aptitudes": ["Agility", "Fieldcraft"],
-            "starter": false,
-            "cost": 0
-          },
-          "survival": {
-            "label": "SKILL.SURVIVAL",
-            "characteristics": [
-              "Per",
-              "Ag",
-              "Int"
-            ],
-            "advance": -20,
-            "isSpecialist": false,
-            "specialities": {},
-            "aptitudes": ["Perception", "Fieldcraft"],
-            "starter": false,
-            "cost": 0
-          },
-          "techUse": {
-            "label": "SKILL.TECH_USE",
-            "characteristics": [
-              "Int",
-              "Ag"
-            ],
-            "advance": -20,
-            "isSpecialist": false,
-            "specialities": {},
-            "aptitudes": ["Intelligence", "Tech"],
-            "starter": false,
-            "cost": 0
-          },
-          "trade": {
-            "label": "SKILL.TRADE",
-            "characteristics": [
-              "Int",
-              "Ag",
-              "Fel"
-            ],
-            "advance": -20,
-            "isSpecialist": true,
-            "aptitudes": ["Intelligence", "General"],
-            "specialities": {
-              "agri": {
-                "label": "Agri",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "archaeologist": {
-                "label": "Archaeologist",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "armourer": {
-                "label": "Armourer",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "astrographer": {
-                "label": "Astrographer",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "chymist": {
-                "label": "Chymist",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "cryptographer": {
-                "label": "Cryptographer",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "cook": {
-                "label": "Cook",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "explorator": {
-                "label": "Explorator",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "linguist": {
-                "label": "Linguist",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "loremancer": {
-                "label": "Loremancer",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "morticator": {
-                "label": "Morticator",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "performancer": {
-                "label": "Performancer",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "prospector": {
-                "label": "Prospector",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "scrimshawer": {
-                "label": "Scrimshawer",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "sculptor": {
-                "label": "Sculptor",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "shipwright": {
-                "label": "Shipwright",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "soothsayer": {
-                "label": "Soothsayer",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "technomat": {
-                "label": "Technomat",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              },
-              "voidfarer": {
-                "label": "Voidfarer",
-                "advance": -20,
-                "starter": false,
-                "cost": 0
-              }
-            }
-          }
-        }
-      },
-      "initiative": {
-        "initiative": {
-          "characteristic": "agility",
-          "base": "1d10"
-        }
-      },
-      "wounds": {
-        "wounds": {
-          "max": 0,
-          "value": 0,
-          "critical": 0
-        }
-      },
-      "fatigue": {
-        "fatigue": {
-          "max": 0,
-          "value": 0
-        }
-      },
-      "fate": {
-        "fate": {
-          "max": 0,
-          "value": 0
-        }
-      },
-      "psy": {
-        "psy": {
-          "rating": 0,
-          "sustained": 0,
-          "class": "bound",
-          "cost": 0
-        }
-      }
-    },
-    "acolyte": {
-      "templates": [
-        "characteristics",
-        "skills",
-        "initiative",
-        "wounds",
-        "fatigue",
-        "fate",
-        "psy"
-      ],
-      "bio": {
-        "homeWorld": "",
-        "background": "",
-        "role": "",
-        "elite": "",
-        "divination": "",
-        "gender": "",
-        "age": "",
-        "build": "",
-        "complexion": "",
-        "hair": "",
-        "quirks": "",
-        "superstition": "",
-        "momentos": "",
-        "notes": ""
-      },
-      "experience": {
-        "value": 0
-      },
-      "insanity": 0,
-      "corruption": 0,
-      "aptitudes": {},
-      "size": 4
-    },
-    "npc": {
-      "templates": [
-        "characteristics",
-        "skills",
-        "initiative",
-        "wounds",
-        "fatigue",
-        "fate",
-        "psy"
-      ],
-      "experience": {
-        "value": 0
-      },
-      "faction": "",
-      "subfaction": "",
-      "type": "troop",
-      "threatLevel": 0,
-      "size": 4,
-      "notes": ""
-    }
-  },
-  "Item": {
-    "types": [
-      "ammunition",
-      "aptitude",
-      "armour",
-      "criticalInjury",
-      "cybernetic",
-      "drug",
-      "forceField",
-      "gear",
-      "malignancy",
-      "mentalDisorder",
-      "mutation",
-      "psychicPower",
-      "specialAbility",
-      "talent",
-      "tool",
-      "trait",
-      "weapon",
-      "weaponModification"
-    ],
-    "templates": {
-      "equipment": {
-        "craftsmanship": "common",
-        "description": "",
-        "availability": "common",
-        "weight": 0
-      },
-      "itemDescription": {
-        "description": "",
-        "source": ""
-      }
-    },
-    "ammunition": {
-      "templates": [ "equipment" ],
-      "quantity": 0,
-      "effect": {
-        "damage": {
-          "modifier": 0,
-          "type": "impact"
         },
-        "special": "",
-        "penetration": "",
-        "attack": {
-          "modifier": 0
+        "acolyte": {
+            "templates": [
+                "characteristics",
+                "skills",
+                "initiative",
+                "wounds",
+                "fatigue",
+                "fate",
+                "psy"
+            ],
+            "bio": {
+                "homeWorld": "",
+                "background": "",
+                "role": "",
+                "elite": "",
+                "divination": "",
+                "gender": "",
+                "age": "",
+                "build": "",
+                "complexion": "",
+                "hair": "",
+                "quirks": "",
+                "superstition": "",
+                "momentos": "",
+                "notes": ""
+            },
+            "experience": {
+                "value": 0
+            },
+            "insanity": 0,
+            "corruption": 0,
+            "aptitudes": {},
+            "size": 4
+        },
+        "npc": {
+            "templates": [
+                "characteristics",
+                "skills",
+                "initiative",
+                "wounds",
+                "fatigue",
+                "fate",
+                "psy"
+            ],
+            "experience": {
+                "value": 0
+            },
+            "faction": "",
+            "subfaction": "",
+            "type": "troop",
+            "threatLevel": 0,
+            "size": 4,
+            "notes": ""
         }
-      },
-      "weapon": ""
     },
-    "armour": {
-      "templates": [ "equipment" ],
-      "type": "basic",
-      "isAdditive": false,
-      "part": {
-        "head": 0,
-        "leftArm": 0,
-        "rightArm": 0,
-        "body": 0,
-        "leftLeg": 0,
-        "rightLeg": 0
-      },
-      "maxAgility": 0
-    },
-    "criticalInjury": {
-      "templates": ["itemDescription"],
-      "type": "impact",
-      "part": "body"
-    },
-    "cybernetic": {
-      "templates": [ "equipment" ],
-      "installed": false
-    },
-    "drug": {
-      "templates": [ "equipment" ],
-      "shortDescription": ""
-    },
-    "forceField": {
-      "templates": [ "equipment" ],
-      "protectionRating": 0,
-      "overloadChance": 0
-    },
-    "gear": {
-      "templates": [ "equipment" ],
-      "shortDescription": ""
-    },
-    "malignancy": {
-      "templates": ["itemDescription"]
-    },
-    "mentalDisorder": {
-      "templates": ["itemDescription"]
-    },
-    "mutation": {
-      "templates": ["itemDescription"]
-    },
-    "psychicPower": {
-      "templates": ["itemDescription"],
-      "shortDescription": "",
-      "cost": 0,
-      "prerequisite": "",
-      "action": "",
-      "focusPower": {
-        "difficulty": 0,
-        "test": ""
-      },
-      "range": "",
-      "sustained": "",
-      "subtype": "",
-      "effect": "",
-      "damage": {
-        "zone": "bolt",
-        "type": "energy",
-        "formula": "",
-        "penetration": "",
-        "special": ""
-      }
-    },
-    "specialAbility": {
-      "templates": ["itemDescription"],
-      "benefit": ""
-    },
-    "talent": {
-      "templates": ["itemDescription"],
-      "prerequisites": "",
-      "aptitudes": "",
-      "benefit": "",
-      "tier": 0,
-      "starter": false,
-      "cost": 0
-    },
-    "tool": {
-      "templates": [ "equipment" ],
-      "shortDescription": ""
-    },
-    "trait": {
-      "templates": ["itemDescription"],
-      "benefit": ""
-    },
-    "weapon": {
-      "templates": [ "equipment" ],
-      "class": "",
-      "type": "",
-      "range": 0,
-      "rateOfFire": {
-        "single": 0,
-        "burst": 0,
-        "full": 0
-      },
-      "damage": "",
-      "damageType": "impact",
-      "penetration": "",
-      "clip": {
-        "max": 0,
-        "value": 0
-      },
-      "reload": "",
-      "special": "",
-      "attack": 0,
-      "ammo" : ""
-    },
-    "weaponModification": {
-      "templates": [ "equipment" ],
-      "upgrades": "",
-      "installed": false
-    },
-    "aptitude" : {
-      "templates": ["itemDescription"]
+    "Item": {
+        "types": [
+            "ammunition",
+            "aptitude",
+            "armour",
+            "criticalInjury",
+            "cybernetic",
+            "drug",
+            "forceField",
+            "gear",
+            "malignancy",
+            "mentalDisorder",
+            "mutation",
+            "psychicPower",
+            "specialAbility",
+            "talent",
+            "tool",
+            "trait",
+            "weapon",
+            "weaponModification"
+        ],
+        "templates": {
+            "equipment": {
+                "craftsmanship": "common",
+                "description": "",
+                "availability": "common",
+                "weight": 0
+            },
+            "itemDescription": {
+                "description": "",
+                "source": ""
+            }
+        },
+        "ammunition": {
+            "templates": [
+                "equipment"
+            ],
+            "quantity": 0,
+            "effect": {
+                "damage": {
+                    "modifier": 0,
+                    "type": "impact"
+                },
+                "special": "",
+                "penetration": "",
+                "attack": {
+                    "modifier": 0
+                }
+            },
+            "weapon": ""
+        },
+        "armour": {
+            "templates": [
+                "equipment"
+            ],
+            "type": "basic",
+            "isAdditive": false,
+            "part": {
+                "head": 0,
+                "leftArm": 0,
+                "rightArm": 0,
+                "body": 0,
+                "leftLeg": 0,
+                "rightLeg": 0
+            },
+            "maxAgility": 0
+        },
+        "criticalInjury": {
+            "templates": [
+                "itemDescription"
+            ],
+            "type": "impact",
+            "part": "body"
+        },
+        "cybernetic": {
+            "templates": [
+                "equipment"
+            ],
+            "installed": false
+        },
+        "drug": {
+            "templates": [
+                "equipment"
+            ],
+            "shortDescription": ""
+        },
+        "forceField": {
+            "templates": [
+                "equipment"
+            ],
+            "protectionRating": 0,
+            "overloadChance": 0
+        },
+        "gear": {
+            "templates": [
+                "equipment"
+            ],
+            "shortDescription": ""
+        },
+        "malignancy": {
+            "templates": [
+                "itemDescription"
+            ]
+        },
+        "mentalDisorder": {
+            "templates": [
+                "itemDescription"
+            ]
+        },
+        "mutation": {
+            "templates": [
+                "itemDescription"
+            ]
+        },
+        "psychicPower": {
+            "templates": [
+                "itemDescription"
+            ],
+            "shortDescription": "",
+            "cost": 0,
+            "prerequisite": "",
+            "action": "",
+            "focusPower": {
+                "difficulty": 0,
+                "test": ""
+            },
+            "range": "",
+            "sustained": "",
+            "subtype": "",
+            "effect": "",
+            "damage": {
+                "zone": "bolt",
+                "type": "energy",
+                "formula": "",
+                "penetration": "",
+                "special": ""
+            }
+        },
+        "specialAbility": {
+            "templates": [
+                "itemDescription"
+            ],
+            "benefit": ""
+        },
+        "talent": {
+            "templates": [
+                "itemDescription"
+            ],
+            "prerequisites": "",
+            "aptitudes": "",
+            "benefit": "",
+            "tier": 0,
+            "starter": false,
+            "cost": 0
+        },
+        "tool": {
+            "templates": [
+                "equipment"
+            ],
+            "shortDescription": ""
+        },
+        "trait": {
+            "templates": [
+                "itemDescription"
+            ],
+            "benefit": ""
+        },
+        "weapon": {},
+        "weaponModification": {
+            "templates": [
+                "equipment"
+            ],
+            "upgrades": "",
+            "installed": false
+        },
+        "aptitude": {
+            "templates": [
+                "itemDescription"
+            ]
+        }
     }
-  }
 }

--- a/template/sheet/actor/tab/gear.hbs
+++ b/template/sheet/actor/tab/gear.hbs
@@ -27,8 +27,8 @@
             </div>
             <div class="items">
                 {{#each items.weapons as |item|}}
-                    <div class="gear item">
-                        <div class="flex row" data-item-id="{{item.id}}">
+                    <div class="gear item" data-item-id="{{item.id}}">
+                        <div class="flex row">
                             <div class="flex name item-edit">
                                 <div class="image-container">
                                     <div class="image" style="background-image: url('{{item.img}}')"></div>

--- a/template/sheet/actor/tab/gear.hbs
+++ b/template/sheet/actor/tab/gear.hbs
@@ -27,22 +27,30 @@
             </div>
             <div class="items">
                 {{#each items.weapons as |item|}}
-                    <div class="gear item flex row" data-item-id="{{item.id}}">
-                        <div class="flex name item-edit">
-                            <div class="image-container">
-                                <div class="image" style="background-image: url('{{item.img}}')"></div>
+                    <div class="gear item">
+                        <div class="flex row" data-item-id="{{item.id}}">
+                            <div class="flex name item-edit">
+                                <div class="image-container">
+                                    <div class="image" style="background-image: url('{{item.img}}')"></div>
+                                </div>
+                                <div>{{item.name}}</div>
                             </div>
-                            <div>{{item.name}}</div>
+                            <div class="class">{{item.WeaponClass}}</div>
+                            <div class="class">{{item.WeaponType}}</div>
+                            <div class="damage">{{item.damage}}</div>
+                            <div class="type">{{item.DamageTypeShort}}</div>
+                            <div class="clip">{{item.Clip}}</div>
+                            <div class="weight">{{item.weight}}</div>
+                            <div class="button">
+                                <a class="item-control item-delete" title="Delete Weapon"><i
+                                        class="fas fa-trash"></i></a>
+                            </div>
                         </div>
-                        <div class="class">{{item.WeaponClass}}</div>
-                        <div class="class">{{item.WeaponType}}</div>
-                        <div class="damage">{{item.damage}}</div>
-                        <div class="type">{{item.DamageTypeShort}}</div>
-                        <div class="clip">{{item.Clip}}</div>
-                        <div class="weight">{{item.weight}}</div>
-                        <div class="button">
-                            <a class="item-control item-delete" title="Delete Weapon"><i class="fas fa-trash"></i></a>
-                        </div>
+                        {{#if item.system.ammoItem}}
+                            <div class="linked-item">
+                                &#8627 {{item.system.ammoItem.name}}
+                            </div>
+                        {{/if}}
                     </div>
                 {{/each}}
             </div>
@@ -53,10 +61,11 @@
                 <b class="installed">{{localize "WEAPON_MODIFICATION.INSTALLED"}}</b>
                 <b class="upgrade">{{localize "WEAPON_MODIFICATION.UPGRADES"}}</b>
                 <b class="weight">{{localize "WEAPON_MODIFICATION.WEIGHT"}}</b>
-                <a class="button item-create" title="Add Weapon Modification" data-type="weaponModification"><i class="fas fa-plus"></i></a>
+                <a class="button item-create" title="Add Weapon Modification" data-type="weaponModification"><i
+                        class="fas fa-plus"></i></a>
             </div>
             <div class="items">
-                {{#each items.weaponMods as |item|}}                    
+                {{#each items.weaponMods as |item|}}
                     <div class="gear item flex row" data-item-id="{{item.id}}">
                         <div class="flex name item-edit">
                             <div class="image-container">
@@ -68,10 +77,11 @@
                         <div class="upgrade">{{item.upgrades}}</div>
                         <div class="weight">{{item.weight}}</div>
                         <div class="button">
-                            <a class="item-control item-delete" title="Delete Weapon Modification"><i class="fas fa-trash"></i></a>
+                            <a class="item-control item-delete" title="Delete Weapon Modification"><i
+                                    class="fas fa-trash"></i></a>
                         </div>
                     </div>
-                    
+
                 {{/each}}
             </div>
         </div>
@@ -82,25 +92,27 @@
                 <b class="quantity">{{localize "AMMUNITION.QUANTITY"}}</b>
                 <b class="weight">{{localize "AMMUNITION.WEIGHT"}}</b>
                 <b class="sum-weight">{{localize "AMMUNITION.SUM"}}</b>
-                <a class="button item-create" title="Add Ammunition" data-type="ammunition"><i class="fas fa-plus"></i></a>
+                <a class="button item-create" title="Add Ammunition" data-type="ammunition"><i
+                        class="fas fa-plus"></i></a>
             </div>
             <div class="items">
-                {{#each items.ammunitions as |item|}}                    
+                {{#each items.ammunitions as |item|}}
                     <div class="gear item flex row" data-item-id="{{item.id}}">
-                    <div class="flex name item-edit">
-                        <div class="image-container">
-                            <div class="image" style="background-image: url('{{item.img}}')"></div>
+                        <div class="flex name item-edit">
+                            <div class="image-container">
+                                <div class="image" style="background-image: url('{{item.img}}')"></div>
+                            </div>
+                            <div>{{item.name}}</div>
                         </div>
-                        <div>{{item.name}}</div>
+                        <div class="weapon">{{item.weapon}}</div>
+                        <div class="quantity">{{item.quantity}}</div>
+                        <div class="weight">{{item.weight}}</div>
+                        <div class="sum-weight">{{item.weightSum}}</div>
+                        <div class="button">
+                            <a class="item-control item-delete" title="Delete Ammunition"><i
+                                    class="fas fa-trash"></i></a>
+                        </div>
                     </div>
-                    <div class="weapon">{{item.weapon}}</div>
-                    <div class="quantity">{{item.quantity}}</div>
-                    <div class="weight">{{item.weight}}</div>
-                    <div class="sum-weight">{{item.weightSum}}</div>
-                    <div class="button">
-                        <a class="item-control item-delete" title="Delete Ammunition"><i class="fas fa-trash"></i></a>
-                    </div>
-                </div>
                 {{/each}}
             </div>
         </div>
@@ -134,7 +146,8 @@
                 <b class="name">{{localize "FORCE_FIELD.HEADER"}}</b>
                 <b class="craftsmanship">{{localize "FORCE_FIELD.CRAFTSMANSHIP"}}</b>
                 <b class="weight">{{localize "FORCE_FIELD.WEIGHT"}}</b>
-                <a class="button item-create" title="Add Force Field" data-type="forceField"><i class="fas fa-plus"></i></a>
+                <a class="button item-create" title="Add Force Field" data-type="forceField"><i
+                        class="fas fa-plus"></i></a>
             </div>
             <div class="items">
                 {{#each items.forceFields as |item|}}
@@ -148,7 +161,8 @@
                         <div class="craftsmanship">{{item.Craftsmanship}}</div>
                         <div class="weight">{{item.weight}}</div>
                         <div class="button">
-                            <a class="item-control item-delete" title="Delete Force Field"><i class="fas fa-trash"></i></a>
+                            <a class="item-control item-delete" title="Delete Force Field"><i
+                                    class="fas fa-trash"></i></a>
                         </div>
                     </div>
                 {{/each}}
@@ -187,7 +201,7 @@
                 <a class="button item-create" title="Add Drug" data-type="drug"><i class="fas fa-plus"></i></a>
             </div>
             <div class="items">
-                {{#each items.drugs as |item|}}                    
+                {{#each items.drugs as |item|}}
                     <div class="gear item flex row" data-item-id="{{item.id}}">
                         <div class="flex name item-edit">
                             <div class="image-container">
@@ -200,7 +214,7 @@
                         <div class="button">
                             <a class="item-control item-delete" title="Delete Drug"><i class="fas fa-trash"></i></a>
                         </div>
-                    </div>                    
+                    </div>
                 {{/each}}
             </div>
         </div>
@@ -212,7 +226,7 @@
                 <a class="button item-create" title="Add Tool" data-type="tool"><i class="fas fa-plus"></i></a>
             </div>
             <div class="items">
-                {{#each items.tools as |item|}}                    
+                {{#each items.tools as |item|}}
                     <div class="gear item flex row" data-item-id="{{item.id}}">
                         <div class="flex name item-edit">
                             <div class="image-container">
@@ -225,7 +239,7 @@
                         <div class="button">
                             <a class="item-control item-delete" title="Delete Tool"><i class="fas fa-trash"></i></a>
                         </div>
-                    </div>                    
+                    </div>
                 {{/each}}
             </div>
         </div>
@@ -235,10 +249,11 @@
                 <b class="installed">{{localize "CYBERNETIC.INSTALLED"}}</b>
                 <b class="cybernetic-craftsmanship">{{localize "CYBERNETIC.CRAFTSMANSHIP"}}</b>
                 <b class="weight">{{localize "CYBERNETIC.WEIGHT"}}</b>
-                <a class="button item-create" title="Add Cybernetic" data-type="cybernetic"><i class="fas fa-plus"></i></a>
+                <a class="button item-create" title="Add Cybernetic" data-type="cybernetic"><i
+                        class="fas fa-plus"></i></a>
             </div>
             <div class="items">
-                {{#each items.cybernetics as |item|}}                    
+                {{#each items.cybernetics as |item|}}
                     <div class="gear item flex row" data-item-id="{{item.id}}">
                         <div class="flex name item-edit">
                             <div class="image-container">
@@ -250,7 +265,8 @@
                         <div class="cybernetic-craftsmanship">{{item.Craftsmanship}}</div>
                         <div class="weight">{{item.weight}}</div>
                         <div class="button">
-                            <a class="item-control item-delete" title="Delete Cybernetic"><i class="fas fa-trash"></i></a>
+                            <a class="item-control item-delete" title="Delete Cybernetic"><i
+                                    class="fas fa-trash"></i></a>
                         </div>
                     </div>
                 {{/each}}


### PR DESCRIPTION
This will introduce the possibility to link ammo to weapons

![grafik](https://github.com/user-attachments/assets/677a0d24-01f2-4cd8-b041-56ee16879143)

As shown, the ammo will appear under the weapon and the weapon name will appear in the weapon field of the ammo.

The linking happens when an ammo item is dropped onto a weapon sheet from a weapon that belongs to an actor.
When another ammo is dropped onto a weapon that already has ammo, the old ammo will be replaced

What is automated:
- damage bonus
- penetration bonus

What is ignored:
- Damage type of ammunition
- Quantity =>  clips

What is currently not possible:
- Unlinking ammo to a weapon
  - currently it can only be replaced