### PR TITLE
convert weapon rate of fire to int

### DIFF
--- a/script/data/item/weaponData.js
+++ b/script/data/item/weaponData.js
@@ -49,4 +49,24 @@ export default class WeaponData extends EquipmentItemData {
         }
     }
 
+
+    /** @inheritdoc */
+    static migrateData(source) {
+        super.migrateData(source);
+
+        this.migrateRateOfFire(source);
+    }
+
+    static migrateRateOfFire(source) {
+        if (
+            !Number.isInteger(source.rateOfFire.single)
+            || !Number.isInteger(source.rateOfFire.burst)
+            || !Number.isInteger(source.rateOfFire.full)
+        ) {
+            source.rateOfFire.single = parseInt(source.rateOfFire.single) || 0;
+            source.rateOfFire.burst = parseInt(source.rateOfFire.single) || 0;
+            source.rateOfFire.full = parseInt(source.rateOfFire.single) || 0;
+        }
+    }
+
 }


### PR DESCRIPTION
in 764cc75af431cbdc61092d5cda165894cffd35cd weapon were coded to only accept numbers. This is now also enforced in the data model. I added a migration to not break old data