### PR TITLE
improve non-square images as avatar

### DIFF
--- a/less/sheet/actor/actor.less
+++ b/less/sheet/actor/actor.less
@@ -204,9 +204,9 @@
             transparent 100%
     );
     flex: 0 0 auto;
-    height: 95px;
+    max-height: 95px;
     margin-right: 8px;
-    width: 95px;
+    max-width: 95px;
 }
 
 .dark-heresy.sheet .header .avatar img {


### PR DESCRIPTION
This little css fix allows non-square images to look good

Before:
![grafik](https://github.com/user-attachments/assets/b52d4a43-e886-47db-872e-080fa137835b)
![grafik](https://github.com/user-attachments/assets/c0185d31-5a0b-4889-bc09-7ea48aba0f3a)
![grafik](https://github.com/user-attachments/assets/bb0f1865-e688-4352-b801-69c67223932d)



After:
![grafik](https://github.com/user-attachments/assets/53645979-cf30-4e68-93e2-9ea76c2100b0)
![grafik](https://github.com/user-attachments/assets/eab82bce-db9d-411a-a684-6f91c437a129)
![grafik](https://github.com/user-attachments/assets/673d55b9-9078-4c2e-9c5a-18ad7e5c6e46)
