### PR TITLE
add AA setting for crit damage

### DIFF
--- a/script/dark-heresy.js
+++ b/script/dark-heresy.js
@@ -31,6 +31,7 @@ import Dh from "./common/config.js";
 // Import Helpers
 import * as chat from "./common/chat.js";
 import { registerDataModels } from "./setup/registerDataModels.js";
+import { registerAdditionalModuleSettings } from "./moduleSupport/moduleSupportSettings.js";
 
 Hooks.once("init", function() {
     CONFIG.Combat.initiative = { formula: "@initiative.base + @initiative.bonus", decimals: 0 };
@@ -103,6 +104,7 @@ Hooks.once("init", function() {
         type: Boolean
     });
 
+    registerAdditionalModuleSettings();
 });
 
 Hooks.once("ready", function() {

--- a/script/moduleSupport/moduleSupportSettings.js
+++ b/script/moduleSupport/moduleSupportSettings.js
@@ -1,0 +1,13 @@
+export const registerAdditionalModuleSettings = function() {
+
+    if (game.modules.get("autoanimations")?.active) {
+        game.settings.register("autoanimations", "criticalAnimation", {
+            name: "Righteous Fury Effect",
+            hint: "This will play an effect on the token that scores a righteous fury",
+            scope: "world",
+            config: true,
+            type: String
+        });
+    }
+
+}


### PR DESCRIPTION
complementary PR to https://github.com/otigon/automated-jb2a-animations/pull/723

AA is configured to show the effect on the attacking token. If you think it makes more sense to show it on the attacked token I can add the targetTokenId to the rollData and switch it in AA


![crit](https://github.com/user-attachments/assets/c4d89ca5-77dd-48fe-bc6f-c8de4b3607d8)